### PR TITLE
Support a non-default field length

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ An additional configuration option is available:
 
 * HTTPTimeout - Integer value in seconds before timing out when connecting
                 to the RabbitMQ Management API. Defaults to 1 second.
+* FieldLength - Set the number of characters used to encode dimension data.
+                This option should only ever be set if you specifically
+                compiled collectd with a non-default value for
+                DATA_MAX_NAME_LEN in plugin.h.
 
 The following is an example Collectd configuration for this plugin:
 


### PR DESCRIPTION
This plugin uses the plugin_instance field to encode dimension data for
RabbitMQ metrics. The default maximum length of plugin_instance in
collectd is 63 characters. In some cases, the dimension data may
exceed 63 characters, causing data to be truncated.

It is possible that some users will want to recompile collectd to use a
larger field length (DATA_MAX_NAME_LEN in plugin.h). This commit adds a
new configuration option, FieldLength, which enables sending a greater
amount of RabbitMQ dimension data to SignalFx.

This option should _not_ be used unless you are running with a
custom-compiled build of collectd that has a modified DATA_MAX_NAME_LEN.

An additional change made in this commit is the "name" dimension is
given protection priority when truncating dimension data beyond the
field length. This may cause some RabbitMQ-specific dimension names to
change when switching to this version from a prior commit.