### PR TITLE
Fix verbosity level for channel.number

### DIFF
--- a/metric_info.py
+++ b/metric_info.py
@@ -91,7 +91,7 @@ metric_data = {
     },
     'channel.number': {
         'metric_type': 'gauge',
-        'verbosity_level': TRACE
+        'verbosity_level': INFO
     },
     'channel.prefetch_count': {
         'metric_type': 'gauge',


### PR DESCRIPTION
The verbosity level for channel.number was incorrectly set to TRACE. It
should be INFO.

This was causing the number of VHosts to be displayed incorrectly on the
SignalFx default dashboard for RabbitMQ.